### PR TITLE
Added support for comments using "#". Still supports ";"

### DIFF
--- a/INI.tmLanguage
+++ b/INI.tmLanguage
@@ -21,7 +21,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(;).*$\n?</string>
+			<string>^(#|;).*$\n?</string>
 			<key>name</key>
 			<string>comment.line.semi-colon.ini</string>
 		</dict>


### PR DESCRIPTION
I was looking trough some INI files and I found your Syntax highlighting didn't see the comments as comments. Turns out you only have support for comments starting with ";" not for comments starting with "#". This should fix it.
