### PR TITLE
added .lng (language translation files) in filetypes

### DIFF
--- a/INI.tmLanguage
+++ b/INI.tmLanguage
@@ -10,6 +10,7 @@
 		<string>INF</string>
 		<string>reg</string>
 		<string>REG</string>
+		<string>lng</string>
 	</array>
 	<key>name</key>
 	<string>INI</string>

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Installation
 
 Changelog
 -------
+- 2014-05-05 Added *.lng (Language translation files) to fileTypes for highlighting
 - 2013-03-20 Comment allowed anywhere on the line (including on the same line after properties or section declarations).
 
 Credits


### PR DESCRIPTION
*.lng files are used by program authors for translating their programs into different languages. They are most often (likely to 100%) based on `var=value` syntax with semi-colon `;` as the comment prefix.   
