### PR TITLE
Fix newline match for symbols list

### DIFF
--- a/INI.tmLanguage
+++ b/INI.tmLanguage
@@ -50,7 +50,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(\[)(.*?)(\])\s*</string>
+			<string>^\s*(\[)(.*?)(\])</string>
 			<key>name</key>
 			<string>meta.tag.section.ini</string>
 		</dict>


### PR DESCRIPTION
ST3

Example:

```
[header1]
h1 = h1

[header2]

h2 = h2
```

ACTUAL symbols matched:

```
header1 h1
header2
    h2
```

EXPECTED

```
header1
    h1
header2
    h2
```
