### PR TITLE
Add cfg and .editorconfig file extensions

### DIFF
--- a/INI.tmLanguage
+++ b/INI.tmLanguage
@@ -11,6 +11,9 @@
 		<string>reg</string>
 		<string>REG</string>
 		<string>lng</string>
+		<string>cfg</string>
+		<string>CFG</string>
+		<string>.editorconfig</string>
 	</array>
 	<key>name</key>
 	<string>INI</string>


### PR DESCRIPTION
editorconfig files use INI format and I'm pretty sure most `.cfg` files use INI format too, although if you're not happy with the small possibility of detecting false positives that actually aren't in INI format then I'll amend this PR :smile: 