### PR TITLE
Added support for URL shortcuts, which are INI format

### DIFF
--- a/INI.tmLanguage
+++ b/INI.tmLanguage
@@ -13,6 +13,8 @@
 		<string>lng</string>
 		<string>cfg</string>
 		<string>CFG</string>
+		<string>url</string>
+		<string>URL</string>
 		<string>.editorconfig</string>
 	</array>
 	<key>name</key>


### PR DESCRIPTION
Figured URL shortcut links for Windows should be included, since they're also in INI format.
