### PR TITLE
Properly handle escaped quotes in strings

### DIFF
--- a/INI.tmLanguage
+++ b/INI.tmLanguage
@@ -114,7 +114,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(\s*(["']?)(.+?)(\2)\s*(=))?\s*((["']?)(.*?)(\7))\s*(;.*)?$\n?</string>
+			<string>^(\s*(["']?)(.+?)((?:(?&lt;!\\))\2)\s*(=))?\s*((["']?)(.*?)((?:(?&lt;!\\))\7))\s*(;.*)?$\n?</string>
 			<key>name</key>
 			<string>meta.declaration.ini</string>
 		</dict>


### PR DESCRIPTION
Previously, \" would be matched as a literal backslash and a quote. This
allows \" to be matched as an escaped double quote. This is useful for
INI parsers that require some strings be quoted, for example for
gitconfigs.