### PR TITLE
Add support for comments after section headers

### DIFF
--- a/INI.tmLanguage
+++ b/INI.tmLanguage
@@ -53,9 +53,14 @@
 					<key>name</key>
 					<string>punctuation.definition.section.ini</string>
 				</dict>
+				<key>4</key>
+				<dict>
+					<key>name</key>
+					<string>comment.definition.section.ini</string>
+				</dict>
 			</dict>
 			<key>match</key>
-			<string>^\s*(\[)(.*?)(\])</string>
+			<string>^\s*(\[)(.*?)(\])\s*(;.*)?$\n?</string>
 			<key>name</key>
 			<string>meta.tag.section.ini</string>
 		</dict>


### PR DESCRIPTION
There's no canonical definition of what's the INI syntax, but Python's `ConfigParser` supports comments after section headers:

```ini
[section] ; comment
```

This PR adds support for them.